### PR TITLE
Add ability to close a channel from the client

### DIFF
--- a/thrussh/src/client/encrypted.rs
+++ b/thrussh/src/client/encrypted.rs
@@ -317,6 +317,9 @@ impl super::Session {
                 let mut r = buf.reader(1);
                 let channel_num = ChannelId(r.read_u32().map_err(crate::Error::from)?);
                 if let Some(ref mut enc) = self.common.encrypted {
+                    // The CHANNEL_CLOSE message must be sent to the server at this point or the session
+                    // will not be released.
+                    enc.byte(channel_num, msg::CHANNEL_CLOSE);
                     enc.channels.remove(&channel_num);
                 }
                 let c = client.take().unwrap();

--- a/thrussh/src/client/session.rs
+++ b/thrussh/src/client/session.rs
@@ -332,6 +332,14 @@ impl Session {
         }
     }
 
+    pub fn close(&mut self, channel: ChannelId) {
+        if let Some(ref mut enc) = self.common.encrypted {
+            enc.close(channel)
+        } else {
+            unreachable!()
+        }
+    }
+
     pub fn extended_data(&mut self, channel: ChannelId, ext: u32, data: CryptoVec) {
         if let Some(ref mut enc) = self.common.encrypted {
             enc.extended_data(channel, ext, data)

--- a/thrussh/src/session.rs
+++ b/thrussh/src/session.rs
@@ -144,6 +144,10 @@ impl Encrypted {
         self.byte(channel, msg::CHANNEL_EOF);
     }
 
+    pub fn close(&mut self, channel: ChannelId) {
+        self.byte(channel, msg::CHANNEL_CLOSE);
+    }
+
     pub fn sender_window_size(&self, channel: ChannelId) -> usize {
         if let Some(ref channel) = self.channels.get(&channel) {
             channel.sender_window_size as usize


### PR DESCRIPTION
This patch addresses two issues:
1. A client should be able to send a `close` message to the server via a channel
2. When the client receives the CHANNEL_CLOSE message it must also respond to the server wit hthe same message per the spec
(see https://datatracker.ietf.org/doc/html/rfc4254#section-5.3)

> When either party wishes to terminate the channel, it sends
> SSH_MSG_CHANNEL_CLOSE.  Upon receiving this message, a party MUST
> send back an SSH_MSG_CHANNEL_CLOSE unless it has already sent this
> message for the channel.  The channel is considered closed for a
> party when it has both sent and received SSH_MSG_CHANNEL_CLOSE, and
> the party may then reuse the channel number.  A party MAY send
> SSH_MSG_CHANNEL_CLOSE without having sent or received
> SSH_MSG_CHANNEL_EOF.

Signed-off-by: johsnonw <wjohnson@whamcloud.com>