### PR TITLE
Add 'vendored' feature to enable musl cross compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +648,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/thrussh-keys/Cargo.toml
+++ b/thrussh-keys/Cargo.toml
@@ -28,6 +28,9 @@ include = [
     "src/signature.rs",
 ]
 
+[features]
+vendored = ["openssl/vendored"]
+
 [dependencies]
 data-encoding = "2.3"
 byteorder = "1.4"

--- a/thrussh/Cargo.toml
+++ b/thrussh/Cargo.toml
@@ -40,6 +40,7 @@ edition = "2021"
 
 [features]
 default = ["flate2"]
+vendored = ["openssl/vendored"]
 
 [dependencies]
 byteorder = "1.3"


### PR DESCRIPTION
Enable `musl` compile using https://github.com/rust-cross/rust-musl-cross.
See https://github.com/seanmonstar/reqwest/issues/377 for similar feature